### PR TITLE
Fixed syntax of basic example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Tests are written in [Skylark](https://github.com/google/skylark), which is a sm
 #// vim: set ft=python:
 def test_for_team_label():
     if spec["kind"] == "Deployment":
-        labels = spec["spec"]["template"]["metadata"]["labels"]:
+        labels = spec["spec"]["template"]["metadata"]["labels"]
         assert_contains(labels, "team", "should indicate which team owns the deployment")
 
 test_for_team_label()


### PR DESCRIPTION
There seems to be a bug in basic example. If I run the code from master, I got:

```
FATA team.sky:4:65: got ':', want newline         
```

This commit introduces a fix.