### PR TITLE
Feature environment passthru

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ INFO rc.yaml should not use latest images
 WARN rc.yaml ReplicationController should have at least 4 replicas
 ```
 
+## the `environment` variable
+
+`environment` is a global variable passed into the Skylark code which contains a white-listed subset of the calling environment as passed to `kubetest`.
+
+The whitelist is specified with the `--env` commandline option to `kubetest`. Environment variable names are separated by commas.  An example is included in `examples/`. If invoked with the `--env=MINREPLICAS` option, the `MINREPLICAS` environment variable will be available at `environment["MINREPLICAS"].
+
+All variables will be passed through as strings to Skylark, so if type conversion is required, that will need to be done in Skylark code, as in the below example:
+
+```
+if "MINREPLICAS" in environment:
+  minreplicas = int(environment["MINREPLICAS"],10)
+else:
+  minreplicas = 4
+```
+
+
+
 ## The `spec` variable
 
 `spec` is a global variable passed into the Skylark code which contains the structure of the Kubernetes configuration passed in to `kubetest`. You'll need to be reasonably familiar with the structure of the Kubernetes API objects to write tests, but it is possible to write helper methods for common assertions.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -102,8 +102,12 @@ func initEnvironment() map[interface{}]interface{} {
 	for _, name := range strings.Split(envList, ",") {
 		trimmed := strings.TrimSpace(name)
 		value := os.Getenv(trimmed)
-		log.WithFields(log.Fields{trimmed: value}).Info("environment variable")
-		env[trimmed] = value
+		logMessage := "skipping empty environment variable"
+		if value != "" {
+			logMessage = "passing through environment variable"
+			env[trimmed] = value
+		}
+		log.WithFields(log.Fields{trimmed: value}).Info(logMessage)
 	}
 	return env
 }

--- a/examples/tests/main.sky
+++ b/examples/tests/main.sky
@@ -8,9 +8,13 @@ def test_for_latest_image():
 
 
 def test_minimum_replicas():
+    if "MINREPLICAS" in environment:
+      minreplicas = int(environment["MINREPLICAS"],10)
+    else:
+      minreplicas = 4
     if spec["kind"] == "ReplicationController":
-        test = spec["spec"]["replicas"] >= 4
-        assert_true(test, "ReplicationController should have at least 4 replicas")
+        test = spec["spec"]["replicas"] >= minreplicas
+        assert_true(test, "ReplicationController should have at least {0} replicas".format(minreplicas))
 
 
 test_for_latest_image()

--- a/kubetest/kubetest.go
+++ b/kubetest/kubetest.go
@@ -37,7 +37,7 @@ func listTests(testDir string) []string {
 	return files
 }
 
-func Run(config []byte, filePath string, fileName string) bool {
+func Run(config []byte, environment map[interface{}]interface{}, filePath string, fileName string) bool {
 	var spec interface{}
 	yaml.Unmarshal(config, &spec)
 
@@ -54,6 +54,7 @@ func Run(config []byte, filePath string, fileName string) bool {
 	globals := map[string]interface{}{
 		"file_name":           fileName,
 		"spec":                spec,
+		"environment":         environment,
 		"assert_equal":        assert.Equal,
 		"assert_contains":     assert.Contains,
 		"assert_not_contains": assert.NotContains,
@@ -104,7 +105,7 @@ func detectLineBreak(haystack []byte) string {
 	return "\n"
 }
 
-func Runs(config []byte, filePath string, fileName string) bool {
+func Runs(config []byte, environment map[interface{}]interface{}, filePath string, fileName string) bool {
 
 	if len(config) == 0 {
 		log.Error("The document " + fileName + " appears to be empty")
@@ -115,7 +116,7 @@ func Runs(config []byte, filePath string, fileName string) bool {
 	results := make([]bool, 0)
 	for _, element := range bits {
 		if len(element) > 0 {
-			result := Run(element, filePath, fileName)
+			result := Run(element, environment, filePath, fileName)
 			results = append(results, result)
 		}
 	}


### PR DESCRIPTION
`kubetest` is ace! Thankyou!

Added an `--env` option to make whitelisted environment variables available to Skylark tests via an additional global `environment`. This will be useful in my work to pass through certain metadata into the testsuite — initially to supply information for tests concerning resource names, but I'm 100% sure there'll be further applications for it later.

I updated the example tests to demonstrate this feature.

Example invocation:

```
$ MINREPLICAS=8 bin/darwin/amd64/kubetest -e MINREPLICAS -t examples/tests examples/rc.yaml --verbose
INFO setting up environment passthrough            envList=MINREPLICAS
INFO environment variable                          MINREPLICAS=8
INFO examples/rc.yaml should not use latest images
WARN examples/rc.yaml ReplicationController should have at least 8 replicas
```

Environment variables with an empty value are not passed through at all, with the intention being that Skylark code should not have to make any more effort than `if "FOO" in environment: ...`