### PR TITLE
allow override of "stdin" filename

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ var RootCmd = &cobra.Command{
 			for scanner.Scan() {
 				buffer.WriteString(scanner.Text() + "\n")
 			}
-			runSuccess := kubetest.Runs(buffer.Bytes(), testsDir, "stdin")
+			runSuccess := kubetest.Runs(buffer.Bytes(), testsDir, viper.GetString("filename"))
 			if success {
 				success = runSuccess
 			}
@@ -106,4 +106,6 @@ func init() {
 	RootCmd.PersistentFlags().Bool("verbose", false, "Output passes as well as failures")
 	viper.BindPFlag("verbose", RootCmd.PersistentFlags().Lookup("verbose"))
 
+	RootCmd.PersistentFlags().StringP("filename", "f", "stdin", "filename to be displayed when testing manifests read from stdin")
+	viper.BindPFlag("filename", RootCmd.PersistentFlags().Lookup("filename"))
 }


### PR DESCRIPTION
# what is this PR doing?

added a commandline option `--filename` to allow overriding the `stdin` filename displayed when accepting manifests from standard input

# why is it useful/desireable?

I have a loop that kinda looks like the below (pseudo)shell example. A Helm template is rendered to a temporary file (greatly simplified here for brevity) so that the test output displays a filename for any failed tests.

The `--filename` option provided by this PR allows me to delete all the temporary file handling (`mktemp` etc) and simply pipe the output of `helm template ...` directly to `kubetest`.

```
#!/bin/sh
rc=0
cd $HELM_CHART
for values in envs/*yaml; do
  for template in templates/*yaml; do
    helm template . -x $template -f $values > temporary.yaml
    if ! kubetest -t $TESTS temporary.yaml ; then
      rc=1
    fi
    rm -f temporary.yaml
  done
done
exit $rc
```

# behavioural changes

The default behaviour of `kubetest` is not affected by this PR.