### PR TITLE
Fix #17 - fail_now should result in exit code 1

### DIFF
--- a/kubetest/kubetest.go
+++ b/kubetest/kubetest.go
@@ -82,6 +82,7 @@ func Run(config []byte, filePath string, fileName string) bool {
 		message := fmt.Sprintf("%s %s", fileName, result.Message)
 		if result.Kind == assert.AssertionError {
 			log.Error(message)
+			success = false
 		} else if result.Kind == assert.AssertionFailure {
 			log.Warn(message)
 			success = false


### PR DESCRIPTION
This PR ensures that `fail_now` and all other assertions that use `assert.AssertionError` results in an exit code `1`